### PR TITLE
DLT - Write to TMC Docker Image

### DIFF
--- a/.github/workflows/docker_ci.yaml
+++ b/.github/workflows/docker_ci.yaml
@@ -27,5 +27,5 @@ jobs:
           file: ./devops/Dockerfile
           push: true
           tags: |
-            ianrichardferguson/tmc-dlt:${{ github.sha }}
-            ianrichardferguson/tmc-dlt:latest
+            movementcooperative/tmc-dlt:${{ github.sha }}
+            movementcooperative/tmc-dlt:latest


### PR DESCRIPTION
Cleans up Docker build to write to `movementcooperative/tmc-dlt:latest`