### PR TITLE
Proof of concept- use click

### DIFF
--- a/devops/requirements.txt
+++ b/devops/requirements.txt
@@ -4,3 +4,4 @@ psycopg2
 dotenv
 psutil
 google-cloud-bigquery-storage
+click

--- a/src/import_single_table_to_bigquery.py
+++ b/src/import_single_table_to_bigquery.py
@@ -1,4 +1,3 @@
-import os
 from typing import List, Optional, Union
 
 import click
@@ -152,11 +151,11 @@ def main(
     local: bool,
 ):
     """Import data from a PostgreSQL database to BigQuery using dlt."""
-    
+
     if local:
         logger.warning("** LOCAL MODE ENABLED - THIS IS NOT FOR PRODUCTION USE **")
-    
-    logger.debug("** DEBUGGER ACTIVER **")
+
+    logger.debug("** DEBUGGER ACTIVE **")
 
     # Set up environment variables for dlt
     ENV_CONFIG = {**BIGQUERY_DESTINATION_CONFIG, **SQL_SOURCE_CONFIG}

--- a/src/import_single_table_to_bigquery.py
+++ b/src/import_single_table_to_bigquery.py
@@ -1,6 +1,7 @@
 import os
 from typing import List, Optional, Union
 
+import click
 import dlt
 from dlt.sources.sql_database import sql_database
 from sqlalchemy.dialects.postgresql import ARRAY, JSON, JSONB, VARCHAR
@@ -17,21 +18,17 @@ from utilities.setup import (
 ##########
 
 
-def table_adapter_callback(query, table):
-    if os.environ.get("FILTER_CLAUSE"):
+def table_adapter_callback(query, table, filter_clause=None):
+    if filter_clause:
         from sqlalchemy.sql import text
 
-        filter_text = os.environ["FILTER_CLAUSE"]
-
-        query = query.where(text(filter_text))
+        query = query.where(text(filter_clause))
     return query
-
 
 def type_adapter_callback(sql_type):
     if isinstance(sql_type, (JSON, ARRAY, JSONB)):
         return VARCHAR
     return sql_type
-
 
 def run_import(
     vendor_name: str,
@@ -42,19 +39,11 @@ def run_import(
     write_disposition: str,
     row_chunk_size: Optional[int] = 10_000,
     include_views: bool = True,
+    filter_clause: Optional[str] = None,
 ):
     """
     Executes an import from a remote host to the destination warehouse
 
-    Args:
-        vendor_name:                Name of the vendor to sync (for alerting purposes)
-        source_schema_name:         Schema to replicate on the source database
-        source_table_names:         List of tables to replicate OR `None` (this will sync all tables)
-        destination_schema_name:    Schema to write to in TMC's system
-        connection_string:          JDBC string to authenticate source database
-        write_disposition:          One of `append`, `replace`, or `drop`
-        row_chunk_size:             Number of rows to return in a single request
-        include_views:              If `True`, views on the source database will be replicated
     """
 
     logger.info(f"Beginning sync to {destination_schema_name}")
@@ -66,20 +55,23 @@ def run_import(
     else:
         logger.info("BE ADVISED - All tables in the source schema will be replicated")
 
+    def query_callback(query, table):
+        return table_adapter_callback(query, table, filter_clause)
+
     # Establish pipeline connection to BigQuery
     pipeline = dlt.pipeline(
         pipeline_name=f"tmc_{vendor_name}",
         destination="bigquery",
         dataset_name=destination_schema_name,
-        progress=dlt.progress.log(log_period=60, logger=logger),
+        progress=dlt.progress.log(log_period=60, logger=logger)
     )
     # Setup connection to source database
     source_postgres_connection = sql_database(
         credentials=connection_string,
         schema=source_schema_name,
         table_names=source_table_names,
-        chunk_size=row_chunk_size,
-        query_adapter_callback=table_adapter_callback,
+        chunk_size=row_chunk_size or 10_000,
+        query_adapter_callback=query_callback,
         type_adapter_callback=type_adapter_callback,
         include_views=include_views,
     )
@@ -92,40 +84,110 @@ def run_import(
 
 #####
 
-if __name__ == "__main__":
+@click.command()
+@click.option(
+    "--vendor-name",
+    envvar="VENDOR_NAME",
+    required=True,
+    help="Name of the vendor to sync (for alerting purposes)"
+)
+@click.option(
+    "--source-schema-name",
+    envvar="SOURCE_SCHEMA_NAME",
+    required=True,
+    help="Schema to replicate on the source database"
+)
+@click.option(
+    "--source-table-name",
+    envvar="SOURCE_TABLE_NAME",
+    required=True,
+    help="Comma-separated list of tables to replicate or 'all' for all tables"
+)
+@click.option(
+    "--destination-schema-name",
+    envvar="DESTINATION_SCHEMA_NAME",
+    required=True,
+    help="Schema to write to in the destination system"
+)
+@click.option(
+    "--source-write-disposition",
+    envvar="SOURCE_WRITE_DISPOSITION",
+    required=True,
+    type=click.Choice(["append", "replace", "merge"]),
+    help="Write disposition: append, replace, or merge"
+)
+@click.option(
+    "--row-chunk-size",
+    envvar="ROW_CHUNK_SIZE",
+    default=10000,
+    type=int,
+    help="Number of rows to return in a single request"
+)
+@click.option(
+    "--include-views",
+    envvar="INCLUDE_VIEWS",
+    is_flag=True,
+    help="Include views in the replication"
+)
+@click.option(
+    "--filter-clause",
+    envvar="FILTER_CLAUSE",
+    help="Optional SQL filter clause to apply to queries"
+)
+@click.option(
+    "--local",
+    envvar="LOCAL",
+    is_flag=True,
+    help="Enable local mode for development (not for production)"
+)
+def main(
+    vendor_name: str,
+    source_schema_name: str,
+    source_table_name: str,
+    destination_schema_name: str,
+    source_write_disposition: str,
+    row_chunk_size: int,
+    include_views: bool,
+    filter_clause: Optional[str],
+    local: bool,
+):
+    """Import data from a PostgreSQL database to BigQuery using dlt."""
+    
+    if local:
+        logger.warning("** LOCAL MODE ENABLED - THIS IS NOT FOR PRODUCTION USE **")
+    
     logger.debug("** DEBUGGER ACTIVER **")
 
+    # Set up environment variables for dlt
     ENV_CONFIG = {**BIGQUERY_DESTINATION_CONFIG, **SQL_SOURCE_CONFIG}
     set_dlt_environment_variables(ENV_CONFIG)
 
     # Source parameters
     CONNECTION_STRING = get_jdbc_connection_string(config=SQL_SOURCE_CONFIG)
 
-    if os.environ.get("LOCAL") == "true":
-        logger.warning("** LOCAL MODE ENABLED - THIS IS NOT FOR PRODUCTION USE **")
+    if local:
         logger.debug(f"Connection string: {CONNECTION_STRING}")
 
-    SOURCE_SCHEMA_NAME = os.environ["SOURCE_SCHEMA_NAME"]
-    SOURCE_TABLE_NAMES = validate_source_tables(os.environ["SOURCE_TABLE_NAME"])
-    INCLUDE_VIEWS = os.environ.get("INCLUDE_VIEWS") == "true"
+    # Validate and process source table names
+    SOURCE_TABLE_NAMES = validate_source_tables(source_table_name)
 
-    # Destination parameters
-    DESTINATION_SCHEMA_NAME = os.environ["DESTINATION_SCHEMA_NAME"]
-
-    # Sync parameters
-    VENDOR_NAME = os.environ["VENDOR_NAME"]
-    ROW_CHUNK_SIZE = int(os.environ.get("ROW_CHUNK_SIZE", 10_000))
-    WRITE_DISPOSITION = validate_write_dispostiion(
-        os.environ["SOURCE_WRITE_DISPOSITION"]
-    )
+    # Validate write disposition
+    WRITE_DISPOSITION = validate_write_dispostiion(source_write_disposition)
+    if WRITE_DISPOSITION is None:
+        raise ValueError(f"Invalid write disposition: {source_write_disposition}")
 
     run_import(
-        vendor_name=VENDOR_NAME.lower().replace(" ", "_"),
-        source_schema_name=SOURCE_SCHEMA_NAME,
+        vendor_name=vendor_name.lower().replace(" ", "_"),
+        source_schema_name=source_schema_name,
         source_table_names=SOURCE_TABLE_NAMES,
-        destination_schema_name=DESTINATION_SCHEMA_NAME,
+        destination_schema_name=destination_schema_name,
         connection_string=CONNECTION_STRING,
-        row_chunk_size=ROW_CHUNK_SIZE,
+        row_chunk_size=row_chunk_size,
         write_disposition=WRITE_DISPOSITION,
-        include_views=INCLUDE_VIEWS,
+        include_views=include_views,
+        filter_clause=filter_clause,
     )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What is this change?
- Talked about this with Ian the other day, but might be nice to start using a CLI parser (argparser or click or something else, I don't care). This tool seems like a fine place to start since it isn't in use in a ton of places yet it's easier to change than canales.

The problems I'd hope to solve are like
1.) We stop having to rewrite env-var parsing stuff so frequently
2.) The env-var parsing always works in an expected and well typed way- in canales I feel like sometimes "True" or "TRUE" will work to set a flag, other times only "true". 
3.) Make these commands self documenting- `python src/import_single_table_to_bigquery.py --help` explains pretty well what this command does

## Considerations for discussion
- Do we want to actually merge this? if we like it, do we want to apply this more broadly in canales, etc.? Is there a reason to use something other than click for this? 

## How to test changes
Run any import table command you ran previously and it should still work- I tested a couple and they worked fine!